### PR TITLE
Fix #5. Use builtin html.parser for BeautifulSoup consistently

### DIFF
--- a/src/plasTeX/Packages/tests/__init__.py
+++ b/src/plasTeX/Packages/tests/__init__.py
@@ -88,3 +88,11 @@ else:
                                   args=(cmd,))
         thread.start()
         thread.join()
+
+
+from bs4 import BeautifulSoup as _Soup
+
+def BeautifulSoup(markup, parser=None):
+    if parser is None:
+        parser = "html.parser"
+    return _Soup(markup, parser)

--- a/src/plasTeX/Packages/tests/test_Alltt.py
+++ b/src/plasTeX/Packages/tests/test_Alltt.py
@@ -6,13 +6,14 @@ import tempfile
 import shutil
 from plasTeX.TeX import TeX
 from unittest import TestCase
-from bs4 import BeautifulSoup as Soup
+
 
 from hamcrest import assert_that
 from hamcrest import has_property
 from hamcrest import contains
 
 from . import _run_plastex
+from . import BeautifulSoup as Soup
 
 class TestAlltt(TestCase):
 

--- a/src/plasTeX/Packages/tests/test_Longtable.py
+++ b/src/plasTeX/Packages/tests/test_Longtable.py
@@ -4,13 +4,14 @@ import unittest, re, os, tempfile, shutil
 
 from plasTeX.TeX import TeX
 from unittest import TestCase
-from bs4 import BeautifulSoup as Soup
+
 
 from hamcrest import assert_that
 from hamcrest import has_length
 from hamcrest import is_
 #from hamcrest import same_instance
 
+from . import BeautifulSoup as Soup
 
 from . import _run_plastex
 
@@ -110,7 +111,7 @@ class TestLongtables(TestCase):
 
     def testFooters(self):
         footers = [
-           # Test \endfoot
+            # Test \endfoot
             r'M & N & O \\\endhead F & G & H \\\endfoot',
             r'M & N & O \\\endfirsthead F & G & H \\\endfoot',
             r'M & N & O \\\endfirsthead\n X & Y & Z \\\endhead F & G & H \\\endfoot',
@@ -180,9 +181,10 @@ class TestLongtables(TestCase):
             caption = longtables[0].title
 
             # Make sure that the caption node matches the caption on the table
-            table = doc.getElementsByTagName('longtable')[0]
             assert caption is not None, 'Caption is empty'
+
             # JAM: table.caption refers to the /class/
+            #table = doc.getElementsByTagName('longtable')[0]
             #assert table.caption is not None, 'Table caption is empty'
             #assert_that( table.caption, is_(same_instance( caption ) ), 'Caption does not match table caption' )
 


### PR DESCRIPTION
Use the builtin rather than add an external dependency.