### PR TITLE
Add eclipse-toc.xml to the bonchmarks.

### DIFF
--- a/src/plasTeX/tests/benchmarks/align-eclipse-toc.xml
+++ b/src/plasTeX/tests/benchmarks/align-eclipse-toc.xml
@@ -1,0 +1,3 @@
+<?xml version='1.0' encoding='ASCII' ?>
+<toc level="root" levelnum="0" renderVersion="1" label="" href="align.html">
+</toc>

--- a/src/plasTeX/tests/benchmarks/align.html
+++ b/src/plasTeX/tests/benchmarks/align.html
@@ -7,129 +7,129 @@
 <div><table class="eqnarray" cellspacing="0" cellpadding="7" width="100%" id="a0000000002">
 <tr id="a0000000003">
     
-    <td style="width:40%"></td>
+    <td style="width:40%">&nbsp;</td>
     
     
         <td style="vertical-align:middle;
-                                  text-align:right"><img class="math gen" src="images/img-0001.png" alt="$\displaystyle  \frac{\partial }{\partial \beta } {x}’A^{-1}{x} = $" style="vertical-align:&amp;amp;images/img-0001.png-depth;&amp;amp;px;; width:&amp;amp;images/img-0001.png-width;&amp;amp;px;;
-                   height:&amp;amp;images/img-0001.png-height;&amp;amp;px;" /></td>
+                                  text-align:right"><img class="math gen" src="images/img-0001.png" alt="$\displaystyle  \frac{\partial }{\partial \beta } {x}’A^{-1}{x} = $" style="vertical-align:&amp;images/img-0001.png-depth;px;; width:&amp;images/img-0001.png-width;px;;
+                   height:&amp;images/img-0001.png-height;px;" /></td>
     
     
     
     
         <td style="vertical-align:middle;
-                                  text-align:left"><img class="math gen" src="images/img-0002.png" alt="$\displaystyle  -{x}’A^{-1}\dot{A}_\beta A^{-1}{x}  $" style="vertical-align:&amp;amp;images/img-0002.png-depth;&amp;amp;px;; width:&amp;amp;images/img-0002.png-width;&amp;amp;px;;
-                   height:&amp;amp;images/img-0002.png-height;&amp;amp;px;" /></td>
+                                  text-align:left"><img class="math gen" src="images/img-0002.png" alt="$\displaystyle  -{x}’A^{-1}\dot{A}_\beta A^{-1}{x}  $" style="vertical-align:&amp;images/img-0002.png-depth;px;; width:&amp;images/img-0002.png-width;px;;
+                   height:&amp;images/img-0002.png-height;px;" /></td>
     
     
     
-    <td style="width:40%"></td>
-    <td class="eqnnum" style="width:20%"></td>
+    <td style="width:40%">&nbsp;</td>
+    <td class="eqnnum" style="width:20%">&nbsp;</td>
 </tr>
 <tr id="a0000000004">
     
-    <td style="width:40%"></td>
+    <td style="width:40%">&nbsp;</td>
     
     
         <td style="vertical-align:middle;
-                                  text-align:right"><img class="math gen" src="images/img-0003.png" alt="$\displaystyle \frac{\partial }{\partial \beta }A^{-1} = $" style="vertical-align:&amp;amp;images/img-0003.png-depth;&amp;amp;px;; width:&amp;amp;images/img-0003.png-width;&amp;amp;px;;
-                   height:&amp;amp;images/img-0003.png-height;&amp;amp;px;" /></td>
+                                  text-align:right"><img class="math gen" src="images/img-0003.png" alt="$\displaystyle \frac{\partial }{\partial \beta }A^{-1} = $" style="vertical-align:&amp;images/img-0003.png-depth;px;; width:&amp;images/img-0003.png-width;px;;
+                   height:&amp;images/img-0003.png-height;px;" /></td>
     
     
     
     
         <td style="vertical-align:middle;
-                                  text-align:left"><img class="math gen" src="images/img-0004.png" alt="$\displaystyle  -A^{-1}\dot{A}_\beta A^{-1}  $" style="vertical-align:&amp;amp;images/img-0004.png-depth;&amp;amp;px;; width:&amp;amp;images/img-0004.png-width;&amp;amp;px;;
-                   height:&amp;amp;images/img-0004.png-height;&amp;amp;px;" /></td>
+                                  text-align:left"><img class="math gen" src="images/img-0004.png" alt="$\displaystyle  -A^{-1}\dot{A}_\beta A^{-1}  $" style="vertical-align:&amp;images/img-0004.png-depth;px;; width:&amp;images/img-0004.png-width;px;;
+                   height:&amp;images/img-0004.png-height;px;" /></td>
     
     
     
-    <td style="width:40%"></td>
-    <td class="eqnnum" style="width:20%"></td>
+    <td style="width:40%">&nbsp;</td>
+    <td class="eqnnum" style="width:20%">&nbsp;</td>
 </tr>
 <tr id="a0000000005">
     
-    <td style="width:40%"></td>
+    <td style="width:40%">&nbsp;</td>
     
     
         <td style="vertical-align:middle;
-                                  text-align:right"><img class="math gen" src="images/img-0005.png" alt="$\displaystyle \frac{\partial }{\partial \beta } |A| =  $" style="vertical-align:&amp;amp;images/img-0005.png-depth;&amp;amp;px;; width:&amp;amp;images/img-0005.png-width;&amp;amp;px;;
-                   height:&amp;amp;images/img-0005.png-height;&amp;amp;px;" /></td>
+                                  text-align:right"><img class="math gen" src="images/img-0005.png" alt="$\displaystyle \frac{\partial }{\partial \beta } |A| =  $" style="vertical-align:&amp;images/img-0005.png-depth;px;; width:&amp;images/img-0005.png-width;px;;
+                   height:&amp;images/img-0005.png-height;px;" /></td>
     
     
     
     
         <td style="vertical-align:middle;
-                                  text-align:left"><img class="math gen" src="images/img-0006.png" alt="$\displaystyle  \, \, |A| \, {trace}\left( A^{-1}\dot{A}_\beta \right)  $" style="vertical-align:&amp;amp;images/img-0006.png-depth;&amp;amp;px;; width:&amp;amp;images/img-0006.png-width;&amp;amp;px;;
-                   height:&amp;amp;images/img-0006.png-height;&amp;amp;px;" /></td>
+                                  text-align:left"><img class="math gen" src="images/img-0006.png" alt="$\displaystyle  \, \, |A| \, {trace}\left( A^{-1}\dot{A}_\beta \right)  $" style="vertical-align:&amp;images/img-0006.png-depth;px;; width:&amp;images/img-0006.png-width;px;;
+                   height:&amp;images/img-0006.png-height;px;" /></td>
     
     
     
-    <td style="width:40%"></td>
-    <td class="eqnnum" style="width:20%"></td>
+    <td style="width:40%">&nbsp;</td>
+    <td class="eqnnum" style="width:20%">&nbsp;</td>
 </tr>
 <tr id="a0000000006">
     
-    <td style="width:40%"></td>
+    <td style="width:40%">&nbsp;</td>
     
     
         <td style="vertical-align:middle;
-                                  text-align:right"><img class="math gen" src="images/img-0007.png" alt="$\displaystyle \frac{\partial }{\partial \beta } \log \left\{ |A|\right\}  = $" style="vertical-align:&amp;amp;images/img-0007.png-depth;&amp;amp;px;; width:&amp;amp;images/img-0007.png-width;&amp;amp;px;;
-                   height:&amp;amp;images/img-0007.png-height;&amp;amp;px;" /></td>
+                                  text-align:right"><img class="math gen" src="images/img-0007.png" alt="$\displaystyle \frac{\partial }{\partial \beta } \log \left\{ |A|\right\}  = $" style="vertical-align:&amp;images/img-0007.png-depth;px;; width:&amp;images/img-0007.png-width;px;;
+                   height:&amp;images/img-0007.png-height;px;" /></td>
     
     
     
     
         <td style="vertical-align:middle;
-                                  text-align:left"><img class="math gen" src="images/img-0008.png" alt="$\displaystyle  \, \, \frac{1}{|A|}\,  \frac{\partial }{\partial \beta }A= {trace}\left( A^{-1}\dot{A}_\beta \right)  $" style="vertical-align:&amp;amp;images/img-0008.png-depth;&amp;amp;px;; width:&amp;amp;images/img-0008.png-width;&amp;amp;px;;
-                   height:&amp;amp;images/img-0008.png-height;&amp;amp;px;" /></td>
+                                  text-align:left"><img class="math gen" src="images/img-0008.png" alt="$\displaystyle  \, \, \frac{1}{|A|}\,  \frac{\partial }{\partial \beta }A= {trace}\left( A^{-1}\dot{A}_\beta \right)  $" style="vertical-align:&amp;images/img-0008.png-depth;px;; width:&amp;images/img-0008.png-width;px;;
+                   height:&amp;images/img-0008.png-height;px;" /></td>
     
     
     
-    <td style="width:40%"></td>
-    <td class="eqnnum" style="width:20%"></td>
+    <td style="width:40%">&nbsp;</td>
+    <td class="eqnnum" style="width:20%">&nbsp;</td>
 </tr>
 <tr id="a0000000007">
     
-    <td style="width:40%"></td>
+    <td style="width:40%">&nbsp;</td>
     
     
         <td style="vertical-align:middle;
-                                  text-align:right"><img class="math gen" src="images/img-0009.png" alt="$\displaystyle \frac{\partial ^2}{\partial \beta \partial \theta } A^{-1} = $" style="vertical-align:&amp;amp;images/img-0009.png-depth;&amp;amp;px;; width:&amp;amp;images/img-0009.png-width;&amp;amp;px;;
-                   height:&amp;amp;images/img-0009.png-height;&amp;amp;px;" /></td>
+                                  text-align:right"><img class="math gen" src="images/img-0009.png" alt="$\displaystyle \frac{\partial ^2}{\partial \beta \partial \theta } A^{-1} = $" style="vertical-align:&amp;images/img-0009.png-depth;px;; width:&amp;images/img-0009.png-width;px;;
+                   height:&amp;images/img-0009.png-height;px;" /></td>
     
     
     
     
         <td style="vertical-align:middle;
-                                  text-align:left"><img class="math gen" src="images/img-0010.png" alt="$\displaystyle  -A^{-1}\ddot{A}_{\beta \theta }A^{-1} + A^{-1}\dot{A}_\beta A^{-1}\dot{A}_\theta A^{-1} + A^{-1}\dot{A}_\theta A^{-1}\dot{A}_\beta A^{-1}  $" style="vertical-align:&amp;amp;images/img-0010.png-depth;&amp;amp;px;; width:&amp;amp;images/img-0010.png-width;&amp;amp;px;;
-                   height:&amp;amp;images/img-0010.png-height;&amp;amp;px;" /></td>
+                                  text-align:left"><img class="math gen" src="images/img-0010.png" alt="$\displaystyle  -A^{-1}\ddot{A}_{\beta \theta }A^{-1} + A^{-1}\dot{A}_\beta A^{-1}\dot{A}_\theta A^{-1} + A^{-1}\dot{A}_\theta A^{-1}\dot{A}_\beta A^{-1}  $" style="vertical-align:&amp;images/img-0010.png-depth;px;; width:&amp;images/img-0010.png-width;px;;
+                   height:&amp;images/img-0010.png-height;px;" /></td>
     
     
     
-    <td style="width:40%"></td>
-    <td class="eqnnum" style="width:20%"></td>
+    <td style="width:40%">&nbsp;</td>
+    <td class="eqnnum" style="width:20%">&nbsp;</td>
 </tr>
 <tr id="a0000000008">
     
-    <td style="width:40%"></td>
+    <td style="width:40%">&nbsp;</td>
     
     
         <td style="vertical-align:middle;
-                                  text-align:right"><img class="math gen" src="images/img-0011.png" alt="$\displaystyle \frac{\partial ^2}{\partial \beta \partial \theta } \log \left\{ |A|\right\}  = $" style="vertical-align:&amp;amp;images/img-0011.png-depth;&amp;amp;px;; width:&amp;amp;images/img-0011.png-width;&amp;amp;px;;
-                   height:&amp;amp;images/img-0011.png-height;&amp;amp;px;" /></td>
+                                  text-align:right"><img class="math gen" src="images/img-0011.png" alt="$\displaystyle \frac{\partial ^2}{\partial \beta \partial \theta } \log \left\{ |A|\right\}  = $" style="vertical-align:&amp;images/img-0011.png-depth;px;; width:&amp;images/img-0011.png-width;px;;
+                   height:&amp;images/img-0011.png-height;px;" /></td>
     
     
     
     
         <td style="vertical-align:middle;
-                                  text-align:left"><img class="math gen" src="images/img-0012.png" alt="$\displaystyle  \, \, {trace}\left(A^{-1}\ddot{A}_{\beta \theta } \right) - {trace}\left(A^{-1}\dot{A}_\beta A^{-1}\dot{A}_\theta \right)  $" style="vertical-align:&amp;amp;images/img-0012.png-depth;&amp;amp;px;; width:&amp;amp;images/img-0012.png-width;&amp;amp;px;;
-                   height:&amp;amp;images/img-0012.png-height;&amp;amp;px;" /></td>
+                                  text-align:left"><img class="math gen" src="images/img-0012.png" alt="$\displaystyle  \, \, {trace}\left(A^{-1}\ddot{A}_{\beta \theta } \right) - {trace}\left(A^{-1}\dot{A}_\beta A^{-1}\dot{A}_\theta \right)  $" style="vertical-align:&amp;images/img-0012.png-depth;px;; width:&amp;images/img-0012.png-width;px;;
+                   height:&amp;images/img-0012.png-height;px;" /></td>
     
     
     
-    <td style="width:40%"></td>
-    <td class="eqnnum" style="width:20%"></td>
+    <td style="width:40%">&nbsp;</td>
+    <td class="eqnnum" style="width:20%">&nbsp;</td>
 </tr>
 </table></div>
 

--- a/src/plasTeX/tests/benchmarks/footnotes-eclipse-toc.xml
+++ b/src/plasTeX/tests/benchmarks/footnotes-eclipse-toc.xml
@@ -1,0 +1,3 @@
+<?xml version='1.0' encoding='ASCII' ?>
+<toc level="root" levelnum="0" renderVersion="1" label="" href="footnotes.html">
+</toc>

--- a/src/plasTeX/tests/benchmarks/spaces_in_labels-eclipse-toc.xml
+++ b/src/plasTeX/tests/benchmarks/spaces_in_labels-eclipse-toc.xml
@@ -1,0 +1,3 @@
+<?xml version='1.0' encoding='ASCII' ?>
+<toc level="root" levelnum="0" renderVersion="1" label="" href="spaces_in_labels.html">
+</toc>


### PR DESCRIPTION
Make sure it gets generated, although the current benchmarks have one
one section so it's not especially useful.

Also correct a test bug that prevented differences from being reported;
correct the output for align.html since it was now failing.