### PR TITLE
Kill coverage reports for pypy because it's slow. Also kill pypy3 bec…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ python:
   - 3.4
   - 3.5
   - pypy
-  - pypy3
 script:
-  - coverage run `which zope-testrunner` --test-path=src  --auto-color --auto-progress --all
+# Coverage is slow on this old version of pypy
+  - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then coverage run `which zope-testrunner` --test-path=src  --auto-color --auto-progress --all; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then zope-testrunner --test-path=src --all; fi
 after_success:
   - coveralls
 notifications:

--- a/src/plasTeX/Imagers/tests/test_Imager.py
+++ b/src/plasTeX/Imagers/tests/test_Imager.py
@@ -21,6 +21,9 @@ from hamcrest import is_
 from hamcrest import has_length
 from hamcrest.library.collection.is_empty import empty as is_empty
 
+import os
+import importlib
+import glob
 import tempfile
 
 from .. import Imager
@@ -51,3 +54,30 @@ class TestImagers(unittest.TestCase):
 
             new_imager._read_cache(validate_files=True)
             assert_that( new_imager._cache, is_empty() )
+
+
+
+def _make_check(fname):
+    pname = os.path.basename(fname)
+    pname = os.path.splitext(pname)[0]
+
+    def test(self):
+        self._check(pname)
+
+    return  pname, test
+
+class TestImports(unittest.TestCase):
+
+    def _check(self, name):
+        importlib.import_module('plasTeX.Imagers.' + name)
+
+    for _, _fname in enumerate(sorted(glob.glob(os.path.join(os.path.dirname(__file__), '..', "*py")))):
+        pname, test = _make_check(_fname)
+        if pname in ('__init__', ):
+            continue
+        tname = 'test_' + pname
+        if tname not in locals():
+            locals()[tname] = test
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
…ause it's so old.