### PR TITLE
Reduce log level of plasTeX internal bookkeeping.

### DIFF
--- a/src/plasTeX/Base/LaTeX/Environments.py
+++ b/src/plasTeX/Base/LaTeX/Environments.py
@@ -7,7 +7,9 @@ C.1.2 Environments (p167)
 
 from plasTeX import Command
 
-logger = __import__('logging').getLogger(__name__)
+from plasTeX.Logging import getLogger
+
+logger = getLogger(__name__)
 
 class begin(Command):
     """ Beginning of an environment """
@@ -17,7 +19,7 @@ class begin(Command):
         """ Parse the \\begin{...} """
 #       name = self.parse(tex)['name']
         name = tex.readArgument(type=str)
-        logger.debug( 'Begin environment %s', name)
+        logger.debug1( 'Begin environment %s', name)
 
         self.ownerDocument.context.currenvir = name
 
@@ -42,7 +44,7 @@ class end(Command):
         """ Parse the \\end{...} """
 #       name = self.parse(tex)['name']
         name = tex.readArgument(type=str)
-        logger.debug( 'End environment %s', name)
+        logger.debug1( 'End environment %s', name)
 
         # Instantiate the correct macro and let it know
         # that it came from a \end{...} macro

--- a/src/plasTeX/Context.py
+++ b/src/plasTeX/Context.py
@@ -653,11 +653,11 @@ class Context(object):
                 # If we hit a document element, make sure that we start
                 # at the global context.
                 if context.level == context.DOCUMENT_LEVEL:
-                    stacklog.debug( "Popping all contexts up to document due to %r", context )
+                    stacklog.debug1( "Popping all contexts up to document due to %r", context )
 
                     while len(self.contexts) > 1:
                         self.contexts.pop()
-            stacklog.debug('pushing %s onto %s', name, self.top)
+            stacklog.debug1('pushing %s onto %s', name, self.top)
             self.contexts.append(self.createContext(context))
 
         self.mapMethods()
@@ -743,7 +743,7 @@ class Context(object):
 
         """
 
-        #stacklog.debug( 'Popping %s %s from %s', obj, type(obj), self.contexts[-1] )
+        #stacklog.debug1( 'Popping %s %s from %s', obj, type(obj), self.contexts[-1] )
 
         if obj is None:
             # Pop until we hit a None in the context
@@ -945,7 +945,7 @@ class Context(object):
         """
         name = str(name)
         # Generate a new count class
-        macrolog.debug('creating count %s', name)
+        macrolog.debug1('creating count %s', name)
         newclass = type(name, (plasTeX.CountCommand,),
                                {'value': plasTeX.count(initial)})
         self.addGlobal(name, newclass)
@@ -963,7 +963,7 @@ class Context(object):
         """
         name = str(name)
         # Generate a new dimen class
-        macrolog.debug('creating dimen %s', name)
+        macrolog.debug1('creating dimen %s', name)
         newclass = type(name, (plasTeX.DimenCommand,),
                                 {'value': plasTeX.dimen(initial)})
         self.addGlobal(name, newclass)
@@ -981,7 +981,7 @@ class Context(object):
         """
         name = str(name)
         # Generate a new glue class
-        macrolog.debug('creating dimen %s', name)
+        macrolog.debug1('creating dimen %s', name)
         newclass = type(name, (plasTeX.GlueCommand,),
                                 {'value': plasTeX.glue(initial)})
         self.addGlobal(name, newclass)
@@ -999,7 +999,7 @@ class Context(object):
         """
         name = str(name)
         # Generate a new muglue class
-        macrolog.debug('creating muskip %s', name)
+        macrolog.debug1('creating muskip %s', name)
         newclass = type(name, (plasTeX.MuGlueCommand,),
                                 {'value': plasTeX.muglue(initial)})
         self.addGlobal(name, newclass)
@@ -1025,7 +1025,7 @@ class Context(object):
             return
 
         # Generate new 'if' class
-        macrolog.debug('creating if %s', name)
+        macrolog.debug1('creating if %s', name)
         ifclass = type(name, (plasTeX.NewIf,), {'state':initial})
         self.addGlobal(name, ifclass)
 
@@ -1074,7 +1074,7 @@ class Context(object):
         if isinstance(opt, string_types):
             opt = [x for x in Tokenizer(opt, self)]
 
-        macrolog.debug('creating newcommand %s', name)
+        macrolog.debug1('creating newcommand %s', name)
         newclass = type(name, (plasTeX.NewCommand,),
                        {'nargs':nargs,'opt':opt,'definition':definition})
 
@@ -1123,7 +1123,7 @@ class Context(object):
         if isinstance(opt, string_types):
             opt = [x for x in Tokenizer(opt, self)]
 
-        macrolog.debug('creating newenvironment %s', name)
+        macrolog.debug1('creating newenvironment %s', name)
 
         # Begin portion
         newclass = type(name, (plasTeX.NewCommand,),
@@ -1163,7 +1163,7 @@ class Context(object):
         if isinstance(definition, string_types):
             definition = [x for x in Tokenizer(definition, self)]
 
-        macrolog.debug('creating def %s', name)
+        macrolog.debug1('creating def %s', name)
         newclass = type(name, (plasTeX.Definition,),
                        {'args':args,'definition':definition})
 
@@ -1197,7 +1197,7 @@ class Context(object):
         """
         name = str(name)
         # Generate a new chardef class
-        macrolog.debug('creating chardef %s', name)
+        macrolog.debug1('creating chardef %s', name)
         newclass = type(name, (plasTeX.Command,),
                         {'unicode':chr(num)})
         self.addGlobal(name, newclass)

--- a/src/plasTeX/Logging.py
+++ b/src/plasTeX/Logging.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import textwrap, types
 import logging
 from logging import CRITICAL, DEBUG, Logger as _Logger, StreamHandler as _StreamHandler, Formatter
-from logging import addLevelName, setLoggerClass
+from logging import addLevelName, setLoggerClass, getLoggerClass
 
 
 MAX_WIDTH = 75
@@ -23,7 +23,7 @@ addLevelName(DEBUG3, 'DEBUG-3')
 addLevelName(DEBUG4, 'DEBUG-4')
 addLevelName(DEBUG5, 'DEBUG-5')
 
-class Logger(_Logger):
+class Logger(getLoggerClass()):
 
     def __init__(self, name='', *args, **kwargs):
         _Logger.__init__(self, name, *args, **kwargs)
@@ -64,7 +64,7 @@ class Logger(_Logger):
         return self.log(DEBUG5, *args, **kwargs)
 
     def dot(self):
-        return self.debug('.')
+        return self.debug1('.')
 
 
 class StreamFormatter(Formatter):

--- a/src/plasTeX/Renderers/PageTemplate/__init__.py
+++ b/src/plasTeX/Renderers/PageTemplate/__init__.py
@@ -26,8 +26,8 @@ from .interfaces import IXMLTemplateEngine
 from .interfaces import IHTMLTemplateEngine
 from .interfaces import ITemplateEngine
 
-import logging
-log = logging.getLogger(__name__)
+from plasTeX.Logging import getLogger
+log = getLogger(__name__)
 logger = log
 
 from six.moves import configparser as ConfigParser
@@ -140,7 +140,8 @@ class PageTemplate(BaseRenderer):
             engine_type = engine_iface.getTaggedValue('engine_type')
             for name, engine in component.getUtilitiesFor(engine_iface):
                 self.engines[(name, engine_type)] = engine
-
+        if not self.engines: # pragma: no cover
+            logger.warning("No configured template engines found.")
 
     def textDefault(self, node):
         """
@@ -387,7 +388,7 @@ class PageTemplate(BaseRenderer):
             raise ValueError( 'Could not compile template "%s" %s' % (names[0], e) )
 
         for name in names:
-            logger.debug("Storing template %s = %r (%s)", name, template, filename)
+            logger.debug1("Storing template %s = %r (%s)", name, template, filename)
             self[name] = template
 
         return template


### PR DESCRIPTION
Things like newcommand/pushing and popping the stack. This should make
DEBUG logs more useful. If you need that level of detail, go down one
more level in the configuration.

Also properly subclass the logger class from the currently configured
logger class, don't hardcode it.