### PR TITLE
Fix align.tex test on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ python:
   - 2.7
   - 3.4
   - 3.5
-  - pypy
+  - pypy-5.4.1
+dist: trusty
 script:
 # Coverage is slow on this old version of pypy
-  - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then coverage run `which zope-testrunner` --test-path=src  --auto-color --auto-progress --all; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then zope-testrunner --test-path=src --all; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then coverage run `which zope-testrunner` --test-path=src  --auto-color --auto-progress --all; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == pypy* ]]; then zope-testrunner --test-path=src --all; fi
 after_success:
   - coveralls
 notifications:

--- a/src/plasTeX/tests/__init__.py
+++ b/src/plasTeX/tests/__init__.py
@@ -11,17 +11,21 @@ import os
 
 from unittest import SkipTest
 
-def _real_check_for_binaries():
-    with open('/dev/null', 'wb') as f: # Unix specific (prior to Python 3)
-        subprocess.check_call( ['kpsewhich', '--version'], stdout=f)
+def check_for_binary(name='kpsewhich'):
+    try:
+        with open('/dev/null', 'wb') as f: # Unix specific (prior to Python 3)
+            subprocess.check_call( [name, '--version'], stdout=f)
+        return True
+    except OSError:
+        return False
 
-_check_for_binaries = _real_check_for_binaries
+_check_for_binaries = check_for_binary
 
 def _already_checked_for_binaries_and_failed():
     raise SkipTest("kpsewhich binary not found")
 
 def _already_checked_for_binaries_and_worked():
-    return
+    return True
 
 def skip_if_no_binaries():
     """
@@ -32,10 +36,9 @@ def skip_if_no_binaries():
     This is only a partial check and may be slow.
     """
     global _check_for_binaries
-    try:
-        _check_for_binaries()
+    if _check_for_binaries():
         _check_for_binaries = _already_checked_for_binaries_and_worked
-    except OSError:
+    else:
         _check_for_binaries = _already_checked_for_binaries_and_failed
         _already_checked_for_binaries_and_failed()
 


### PR DESCRIPTION
It has no imagers or tex binaries so the HTML only has
DimensionPlaceholder values. The real Dimension is set when images are
rendered (after the HTML has been generated); the HTML has a
placeholder string for the units, and PageTemplate.setImageData is
called by PageTemplate.processFileContent to substitute them in.

But if we have no imager, wehave no unit to substitute.

Prior to a1e0ba5, this test would have been broken when there *was* an
imager available. That commit flipped it.

Ideally we'd have two separate benchmark files to compare the two cases.