### PR TITLE
Fix tests on Python 3, add Python 3.6

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -15,7 +15,7 @@
 
 # invalid-name, ; We get lots of these, especially in scripts. should fix many of them
 # protected-access, ; We have many cases of this; legit ones need to be examinid and commented, then this removed
-# no-self-use, ; common in superclasses with extension points
+# no-self-use, ; common in superclasses with extension points and here, sadly, test cases
 # too-few-public-methods, ; Exception and marker classes get tagged with this
 # exec-used, ; should tag individual instances with this, there are some but not too many
 # global-statement,     ; should tag individual instances
@@ -41,6 +41,7 @@
 #  but they bury more important warnings
 # wrong-import-order,wrong-import-position: same as bad-whitespace
 disable=
+    no-self-use,
     bad-whitespace,
     wrong-import-order,
     wrong-import-position,

--- a/.pylintrc
+++ b/.pylintrc
@@ -37,7 +37,13 @@
 #  def foo():
 #    if baz:
 #      return 1
+# bad-whitespace: Sadly we have millions of these. They do need to be fixed,
+#  but they bury more important warnings
+# wrong-import-order,wrong-import-position: same as bad-whitespace
 disable=
+    bad-whitespace,
+    wrong-import-order,
+    wrong-import-position,
     missing-docstring,
     invalid-name,
     too-few-public-methods,

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,98 @@
+# [MASTER]
+# extension-pkg-whitelist=gevent.libuv._corecffi,gevent.libev._corecffi,gevent.local
+
+[MESSAGES CONTROL]
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once).
+# NOTE: comments must go ABOVE the statement. In Python 2, mixing in
+# comments disables all directives that follow, while in Python 3, putting
+# comments at the end of the line does the same thing (though Py3 supports
+# mixing)
+
+
+# invalid-name, ; We get lots of these, especially in scripts. should fix many of them
+# protected-access, ; We have many cases of this; legit ones need to be examinid and commented, then this removed
+# no-self-use, ; common in superclasses with extension points
+# too-few-public-methods, ; Exception and marker classes get tagged with this
+# exec-used, ; should tag individual instances with this, there are some but not too many
+# global-statement,     ; should tag individual instances
+# multiple-statements, ; "from gevent import monkey; monkey.patch_all()"
+# locally-disabled, ; yes, we know we're doing this. don't replace one warning with another
+# cyclic-import, ; most of these are deferred imports
+# too-many-arguments, ; these are almost always because that's what the stdlib does
+# redefined-builtin, ; likewise: these tend to be keyword arguments like len= in the stdlib
+# undefined-all-variable,     ; XXX: This crashes with pylint 1.5.4 on Travis (but not locally on Py2/3
+#     ; or landscape.io on Py3). The file causing the problem is unclear. UPDATE: identified and disabled
+#   that file.
+#   see https://github.com/PyCQA/pylint/issues/846
+# useless-suppression: the only way to avoid repeating it for specific statements everywhere that we
+#   do Py2/Py3 stuff is to put it here. Sadly this means that we might get better but not realize it.
+# duplicate-code: Yeah, the compatibility ssl modules are much the same
+# In pylint 1.8.0, inconsistent-return-statements are created for the wrong reasons.
+# This code raises it, even though there's only one return (the implicit 'return None' is presumably
+# what triggers it):
+#  def foo():
+#    if baz:
+#      return 1
+disable=
+    missing-docstring,
+    invalid-name,
+    too-few-public-methods,
+    global-statement,
+    locally-disabled,
+    cyclic-import,
+    too-many-arguments,
+    redefined-builtin,
+    useless-suppression,
+    duplicate-code,
+    undefined-all-variable,
+    inconsistent-return-statements
+
+
+[FORMAT]
+max-line-length=100
+max-module-lines=1100
+
+[MISCELLANEOUS]
+# List of note tags to take in consideration, separated by a comma.
+#notes=FIXME,XXX,TODO
+# Disable that, we don't want them in the report (???)
+notes=
+
+[VARIABLES]
+
+dummy-variables-rgx=_.*
+
+[TYPECHECK]
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+# gevent: this is helpful for py3/py2 code.
+generated-members=exc_clear
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set). This supports can work
+# with qualified names.
+# greenlet, Greenlet, parent, dead: all attempts to fix issues in greenlet.py
+# only seen on the service, e.g., self.parent.loop: class parent has no loop
+ignored-classes=SSLContext, SSLSocket, greenlet, Greenlet, parent, dead
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=gevent._corecffi,gevent.os,os,greenlet,threading,gevent.libev.corecffi
+
+[DESIGN]
+max-attributes=12
+
+[BASIC]
+bad-functions=input
+# Prospector turns ot unsafe-load-any-extension by default, but
+# pylint leaves it off. This is the proximal cause of the
+# undefined-all-variable crash.
+#unsafe-load-any-extension = no

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 sudo: false
+env:
+  - CHAMELEON_CACHE=$HOME/.cache/pip
 python:
   - 2.7
   - 3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ python:
   - 2.7
   - 3.4
   - 3.5
-  - pypy-5.4.1
-dist: trusty
+  - 3.6
+  - pypy
 script:
 # Coverage is slow on this old version of pypy
-  - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then coverage run `which zope-testrunner` --test-path=src  --auto-color --auto-progress --all; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then coverage run -m zope.testrunner --test-path=src  --auto-color --auto-progress --all; fi
   - if [[ $TRAVIS_PYTHON_VERSION == pypy* ]]; then zope-testrunner --test-path=src --all; fi
 after_success:
   - coveralls
@@ -22,13 +22,6 @@ install:
   - pip install -U zope.testrunner
   - pip install -U -e ".[test]"
 
-# cache: pip seems not to work if `install` is replaced (https://github.com/travis-ci/travis-ci/issues/3239)
-cache:
-  directories:
-    - $HOME/.cache/pip
-    - $HOME/.venv
-    - $HOME/.runtimes
-    - $HOME/.wheelhouse
-
+cache: pip
 before_cache:
     - rm -f $HOME/.cache/pip/log/debug.log

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,3 +49,5 @@
   extensibility introduced by the component registry.
 
 - Remove Entites.py and ent.xml.
+
+- Add support for Python 3.5 and 3.6 and PyPy.

--- a/setup.py
+++ b/setup.py
@@ -57,22 +57,6 @@ def read(name):
     with open(join(dirname(__file__), name)) as f:
         return f.read().strip()
 
-def alltests():
-    import os
-    import sys
-    import unittest
-    # use the zope.testrunner machinery to find all the
-    # test suites we've put under ourselves.
-    # Based on zope.principalregistry
-    import zope.testrunner.find
-    import zope.testrunner.options
-    here = os.path.abspath(os.path.join(os.path.dirname(__file__), 'src'))
-    args = sys.argv[:]
-    defaults = ["--test-path", here]
-    options = zope.testrunner.options.get_options(args, defaults)
-    suites = list(zope.testrunner.find.find_suites(options))
-    return unittest.TestSuite(suites)
-
 setup(name="nti.plasTeX",
       description="Modern, extensible, LaTeX document processing framework",
       long_description=read('README.rst'),
@@ -90,6 +74,7 @@ setup(name="nti.plasTeX",
           "Programming Language :: Python :: 2.7",
           "Programming Language :: Python :: 3.4",
           "Programming Language :: Python :: 3.5",
+          "Programming Language :: Python :: 3.6",
           "Programming Language :: Python :: Implementation :: CPython",
           "Programming Language :: Python :: Implementation :: PyPy",
           "Programming Language :: Python :: Implementation :: Jython",
@@ -110,6 +95,4 @@ setup(name="nti.plasTeX",
       },
       dependency_links=[
       ],
-      #test_loader="zope.testrunner.eggsupport:SkipLayers",
-      test_suite="__main__.alltests",
 )

--- a/src/plasTeX/Base/LaTeX/Verbatim.py
+++ b/src/plasTeX/Base/LaTeX/Verbatim.py
@@ -14,7 +14,7 @@ class verbatim(Environment):
     captionable = True
 
     def invoke(self, tex):
-        """ Parse until we reach `\end{verbatim}' or `\endverbatim' """
+        """ Parse until we reach ``\\end{verbatim}`` or ``\\endverbatim`` """
         if self.macroMode == Environment.MODE_END:
             return
 
@@ -126,10 +126,9 @@ class verb(Command):
     @property
     def source(self):
         return '\\%s%s%s%s%s' % (self.nodeName, sourceArguments(self),
-                                 self.delimiter, sourceChildren(self), 
+                                 self.delimiter, sourceChildren(self),
                                  self.delimiter)
 
     def normalize(self, charsubs=[]):
         """ Normalize, but don't allow character substitutions """
         return Command.normalize(self)
-

--- a/src/plasTeX/Base/LaTeX/pyuca.py
+++ b/src/plasTeX/Base/LaTeX/pyuca.py
@@ -5,17 +5,17 @@
 # http://jtauber.com/
 
 # Copyright (c) 2006 James Tauber
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -48,7 +48,7 @@ but you can always subset this for just the characters you are dealing with.
 """
 
 
-class Trie:
+class Trie(object):
 
     def __init__(self):
         self.root = [None, {}]
@@ -70,7 +70,7 @@ class Trie:
         return (curr_node[0], remainder)
 
 
-class Collator:
+class Collator(object):
 
     def __init__(self, filename):
 
@@ -78,39 +78,40 @@ class Collator:
         self.load(filename)
 
     def load(self, filename):
-        for line in open(filename):
-            if line.startswith("#") or line.startswith("%"):
-                continue
-            if line.strip() == "":
-                continue
-            line = line[:line.find("#")] + "\n"
-            line = line[:line.find("%")] + "\n"
-            line = line.strip()
-        
-            if line.startswith("@"):
-                pass
-            else:
-                semicolon = line.find(";")
-                charList = line[:semicolon].strip().split()
-                x = line[semicolon:]
-                collElements = []
-                while True:
-                    begin = x.find("[")
-                    if begin == -1:
-                        break                
-                    end = x[begin:].find("]")
-                    collElement = x[begin:begin+end+1]
-                    x = x[begin + 1:]
-    
-                    alt = collElement[1]
-                    chars = collElement[2:-1].split(".")
-                    
-                    collElements.append((alt, chars))
-                integer_points = [int(ch, 16) for ch in charList]
-                self.table.add(integer_points, collElements)
+        with open(filename) as f:
+            for line in f:
+                if line.startswith("#") or line.startswith("%"):
+                    continue
+                if line.strip() == "":
+                    continue
+                line = line[:line.find("#")] + "\n"
+                line = line[:line.find("%")] + "\n"
+                line = line.strip()
+
+                if line.startswith("@"):
+                    pass
+                else:
+                    semicolon = line.find(";")
+                    charList = line[:semicolon].strip().split()
+                    x = line[semicolon:]
+                    collElements = []
+                    while True:
+                        begin = x.find("[")
+                        if begin == -1:
+                            break
+                        end = x[begin:].find("]")
+                        collElement = x[begin:begin+end+1]
+                        x = x[begin + 1:]
+
+                        alt = collElement[1]
+                        chars = collElement[2:-1].split(".")
+
+                        collElements.append((alt, chars))
+                    integer_points = [int(ch, 16) for ch in charList]
+                    self.table.add(integer_points, collElements)
 
     def sort_key(self, string):
-        
+
         collation_elements = []
 
         lookup_key = [ord(ch) for ch in string]
@@ -120,9 +121,9 @@ class Collator:
                 # @@@
                 raise ValueError(map(hex, lookup_key))
             collation_elements.extend(value)
-    
+
         sort_key = []
-        
+
         for level in range(4):
             if level:
                 sort_key.append(0) # level separator
@@ -130,5 +131,5 @@ class Collator:
                 ce_l = int(element[1][level], 16)
                 if ce_l:
                     sort_key.append(ce_l)
-        
+
         return tuple(sort_key)

--- a/src/plasTeX/Base/TeX/Primitives.py
+++ b/src/plasTeX/Base/TeX/Primitives.py
@@ -93,7 +93,7 @@ class MathShift(Command):
         """
         This gets a bit tricky because we need to keep track of both
         our beginning and ending.  We also have to take into
-        account \mbox{}es.
+        account \\mbox{}es.
 
         """
         inEnv = self._getEnvStack(self)
@@ -412,8 +412,8 @@ class catcode(Command):
         a = self.parse(tex)
         self.ownerDocument.context.catcode(chr(a['char']), a['code'])
     def source(self):
-        return '\\catcode`\%s=%s' % (chr(self.attributes['char']),
-                                     self.attributes['code'])
+        return '\\catcode`\\%s=%s' % (chr(self.attributes['char']),
+                                      self.attributes['code'])
     source = property(source)
 
 class csname(Command):

--- a/src/plasTeX/Context.py
+++ b/src/plasTeX/Context.py
@@ -476,16 +476,16 @@ class Context(object):
                 #m = __import__(module, globals(), locals())
                 # JAM: We want to allow for dottednames
                 try:
-                    package = zope.dottedname.resolve.resolve( module_name )
-                except (ValueError,SystemError):
+                    package = zope.dottedname.resolve.resolve(module_name)
+                except (ValueError, SystemError, ImportError):
                     # JAM: plastex tries to put its raw Packages directory
                     # on sys.path. This is broken as soon as any of those packages
                     # try to import each other in an absolute fashion, as is required
                     # in python 3. You get "'Attempted relative import in non-package'" in
                     # Py2 as a ValueError, and in py3 you get " Parent module '' not loaded, cannot perform relative import"
-                    # as a SystemError
+                    # as a SystemError OR ImportError, depending on the version.
                     if '.' not in module_name:
-                        package = zope.dottedname.resolve.resolve( 'plasTeX.Packages.' + module_name )
+                        package = zope.dottedname.resolve.resolve('plasTeX.Packages.' + module_name)
             except ImportError as e:
                 # No Python module
                 if 'No module' in str(e):
@@ -1140,7 +1140,7 @@ class Context(object):
 
     def newdef(self, name, args=None, definition=None, local=True):
         """
-        Create a \def
+        Create a \\def
 
         Required Arguments:
         name -- name of the macro to create
@@ -1177,7 +1177,7 @@ class Context(object):
 
     def let(self, dest, source):
         """
-        Create a \let
+        Create a \\let
 
         Required Arguments:
         dest -- the command sequence to create

--- a/src/plasTeX/Packages/book.py
+++ b/src/plasTeX/Packages/book.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 
-import os, glob
+# XXX: FIXME: Other packages do 'from book import *', meaning
+# our imports that we ourself don't use, could be getting used by them.
+import os
+import glob
 from plasTeX import Command, Environment, TheCounter
 
 def ProcessOptions(options, document):
@@ -13,17 +16,17 @@ def ProcessOptions(options, document):
     context.newcounter('enumiv', resetby='enumiii')
 
     # Sections
-    context.newcounter('part', resetby='volume', 
+    context.newcounter('part', resetby='volume',
                        format='$part')
-    context.newcounter('chapter', resetby='part', 
+    context.newcounter('chapter', resetby='part',
                        format='$chapter')
-    context.newcounter('section', resetby='chapter', 
+    context.newcounter('section', resetby='chapter',
                        format='${thechapter}.${section}')
-    context.newcounter('subsection', resetby='section', 
+    context.newcounter('subsection', resetby='section',
                        format='${thesection}.${subsection}')
-    context.newcounter('subsubsection', resetby='subsection', 
+    context.newcounter('subsubsection', resetby='subsection',
                        format='${thesubsection}.${subsubsection}')
-    context.newcounter('paragraph', resetby='subsubsection', 
+    context.newcounter('paragraph', resetby='subsubsection',
                        format='${thesubsubsection}.${paragraph}')
     context.newcounter('subparagraph', resetby='paragraph',
                        format='${theparagraph}.${subparagraph}')
@@ -38,7 +41,7 @@ def ProcessOptions(options, document):
     context.newcounter('page')
 
     # Floats
-    context.newcounter('figure', resetby='chapter', 
+    context.newcounter('figure', resetby='chapter',
                        format='${thechapter}.${figure}')
     context.newcounter('table', resetby='chapter',
                        format='${thechapter}.${table}')
@@ -59,7 +62,7 @@ def ProcessOptions(options, document):
             language = True
             context.loadLanguage(key, document)
 
-class frontmatter(Command): 
+class frontmatter(Command):
     pass
 
 class mainmatter(Command):
@@ -75,4 +78,4 @@ class appendix(Command):
 
     def invoke(self, tex):
         self.ownerDocument.context.counters['chapter'].setcounter(0)
-        self.ownerDocument.context['thechapter'] = type(self).thechapter 
+        self.ownerDocument.context['thechapter'] = type(self).thechapter

--- a/src/plasTeX/Packages/ifpdf.py
+++ b/src/plasTeX/Packages/ifpdf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 """
-This package is intentionally empty.  The \ifpdf command is implemented
+This package is intentionally empty.  The \\ifpdf command is implemented
 in the TeX/Primitives package.
 
 """

--- a/src/plasTeX/Packages/ifthen.py
+++ b/src/plasTeX/Packages/ifthen.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 """
-This package is not properly implemented.  The \ifthenelse command simply
+This package is not properly implemented.  The \\ifthenelse command simply
 returns the 'false' portion of the command.  Hopefully, some day this will
 be done properly.
 
@@ -10,7 +10,7 @@ be done properly.
 from plasTeX import Command
 
 class ifthenelse(Command):
-    args = 'test:nox then:nox else' 
+    args = 'test:nox then:nox else'
 
     class _not(Command):
         macroName = 'not'
@@ -62,6 +62,3 @@ class setboolean(Command):
 
 class whiledo(Command):
     args = 'test:nox operations'
-
-
-

--- a/src/plasTeX/Packages/listings.py
+++ b/src/plasTeX/Packages/listings.py
@@ -8,11 +8,11 @@ except: pygments = None
 
 class listingsname(Base.Command):
     unicode = 'Listing'
-    
+
 PackageOptions = {}
 
 def ProcessOptions(options, document):
-    document.context.newcounter('listings', 
+    document.context.newcounter('listings',
                                 resetby='chapter',
                                 format='${thechapter}.${listings}')
     PackageOptions.update(options)
@@ -24,20 +24,20 @@ class lstset(Base.Command):
         if 'language' in self.attributes['arguments']:
             self.ownerDocument.context.current_language = \
                 self.attributes['arguments']['language']
-        
+
 class lstlisting(Base.verbatim):
     args = '[ arguments:dict ]'
     counter = 'listings'
-    
+
     def invoke(self, tex):
         if self.macroMode == Base.Environment.MODE_END:
             return
         s = ''.join(Base.verbatim.invoke(self, tex)[1:]).replace('\r','').split('\n')
         _format(self, s)
-        
+
 class lstinline(Base.verb):
     args = '[ arguments:dict ]'
-    
+
     def invoke(self, tex):
         _format(self, ''.join(Base.verb.invoke(self, tex)[2:-1]))
 
@@ -51,11 +51,11 @@ class lstinputlisting(Base.Command):
             raise ValueError('Malformed \\lstinputlisting macro.')
         _format(self, codecs.open(self.attributes['file'], 'r',
             self.config['files']['input-encoding'], 'replace'))
-        
+
 def _format(self, file):
     if self.attributes['arguments'] is None:
         self.attributes['arguments'] = {}
-        
+
     linenos = False
     if 'numbers' in self.attributes['arguments'] or 'numbers' in PackageOptions:
         linenos = 'inline'
@@ -91,7 +91,7 @@ def _format(self, file):
             # Remove single-line "listings" comments. Only
             # comments started by "/*@" and ended by "@*/" are
             # supported.
-            line = re.sub('/\*@[^@]*@\*/', '', line)
+            line = re.sub(r'/\*@[^@]*@\*/', '', line)
 
             # Add the just-read line to the listing.
             self.plain_listing += '\n' + line
@@ -99,8 +99,8 @@ def _format(self, file):
     # Create a syntax highlighted XHTML version of the file using Pygments
     if pygments is not None:
         from pygments import lexers, formatters
-        try: 
+        try:
             lexer = lexers.get_lexer_by_name(self.ownerDocument.context.current_language.lower())
-        except Exception as msg: 
+        except Exception as msg:
             lexer = lexers.TextLexer()
         self.xhtml_listing = pygments.highlight(self.plain_listing, lexer, formatters.HtmlFormatter(linenos=linenos))

--- a/src/plasTeX/Packages/natbib.py
+++ b/src/plasTeX/Packages/natbib.py
@@ -3,9 +3,9 @@
 """
 natbib
 
-TODO: 
+TODO:
     - compress multiple years
-    - \shortcites
+    - \\shortcites
     - Indexing features
     - Bibliography preamble
 
@@ -70,7 +70,7 @@ class bibliography(Base.bibliography):
 
     def loadBibliographyFile(self, tex):
         doc = self.ownerDocument
-        # Clear out any bib info from the standard package.  
+        # Clear out any bib info from the standard package.
         # We have to get our info from the aux file.
         doc.userdata.setPath('bibliography/bibcites', {})
         self.ownerDocument.context.push(self)
@@ -81,7 +81,7 @@ class bibliography(Base.bibliography):
 
 class bibstyle(Base.Command):
     args = 'style:str'
-    
+
 class citestyle(Base.Command):
     args = 'style:str'
 
@@ -107,7 +107,7 @@ class citestyle(Base.Command):
 
     def invoke(self, tex):
         res = Base.Command.invoke(self, tex)
-        try: 
+        try:
             s = self.styles[self.attributes['style']]
         except KeyError:
         #    log.warning('Could not find bibstyle: "%s"',
@@ -116,16 +116,16 @@ class citestyle(Base.Command):
         p = bibpunct.punctuation
         for i, opt in enumerate(['post','open','close','sep','style','dates','years']):
             p[opt] = s[i]
-        return res    
+        return res
 
 class bstyleoption(Text):
-    """ Option that can only be overridden by package options, 
+    """ Option that can only be overridden by package options,
         citestyle, or bibpunct """
 
 class bibliographystyle(citestyle):
     def invoke(self, tex):
         res = Base.Command.invoke(self, tex)
-        try: 
+        try:
             s = self.styles[self.attributes['style']]
         except KeyError:
         #    log.warning('Could not find bibstyle: "%s"',
@@ -135,18 +135,18 @@ class bibliographystyle(citestyle):
         for i, opt in enumerate(['post','open','close','sep','style','dates','years']):
             if isinstance(p[opt], bstyleoption):
                 p[opt] = s[i]
-        return res    
-        
+        return res
+
 class bibpunct(Base.Command):
     """ Set up punctuation of citations """
     args = '[ post:str ] open:str close:str sep:str ' + \
            'style:str dates:str years:str'
-    punctuation = {'post': bstyleoption(', '), 
-                   'open': bstyleoption('('), 
-                   'close':bstyleoption(')'), 
-                   'sep':  bstyleoption(';'), 
-                   'style':bstyleoption('a'), 
-                   'dates':bstyleoption(','), 
+    punctuation = {'post': bstyleoption(', '),
+                   'open': bstyleoption('('),
+                   'close':bstyleoption(')'),
+                   'sep':  bstyleoption(';'),
+                   'style':bstyleoption('a'),
+                   'dates':bstyleoption(','),
                    'years':bstyleoption(',')}
     def invoke(self, tex):
         res = Base.Command.invoke(self, tex)
@@ -156,7 +156,7 @@ class bibpunct(Base.Command):
             elif type(value) == str or type(value) == unicode:
                 bibpunct.punctuation[key] = value
             else:
-                bibpunct.punctuation[key] = value.textContent            
+                bibpunct.punctuation[key] = value.textContent
         return res
 
 class bibcite(Base.Command):
@@ -183,7 +183,7 @@ class thebibliography(Base.thebibliography):
 
         @property
         def bibcite(self):
-            try: 
+            try:
                 doc = self.ownerDocument
                 return doc.userdata.getPath('bibliography/bibcites', {})[self.attributes['key']]
             except KeyError as msg:
@@ -199,7 +199,7 @@ class thebibliography(Base.thebibliography):
                 obj.append('??')
                 value.attributes[item] = obj
             return value
-            
+
         def ref():
             def fset(self, value):
                 pass
@@ -207,7 +207,7 @@ class thebibliography(Base.thebibliography):
                 return self.bibcite.textContent
             return locals()
         ref = property(**ref())
-    
+
 class harvarditem(thebibliography.bibitem):
     args = '[ abbrlabel ] label year key:str'
 
@@ -233,7 +233,7 @@ class NatBibCite(Base.cite):
             if 'sort&compress' in opts or 'sortandcompress' in opts:
                 items = self.compressRange(items)
         return items
-        
+
     def compressRange(self, items):
         """ Compress ranges of numbers """
         idx, idxdict = [], {}
@@ -253,7 +253,7 @@ class NatBibCite(Base.cite):
                 output.append(value)
         output.append(' ')
         output = ''.join([str(x) for x in output])
-        output = re.sub(r'( \d+)-(\d+ )', r'\1 \2', output) 
+        output = re.sub(r'( \d+)-(\d+ )', r'\1 \2', output)
         while re.search(r'-\d+-', output):
             output = re.sub(r'-\d+-', r'-', output)
         output = [x for x in re.split(r'([ -])', output) if x.strip()]
@@ -263,10 +263,10 @@ class NatBibCite(Base.cite):
             else:
                 output[i] = self.Connector(value)
         return output
-        
+
     def isConnector(self, value):
         return isinstance(value, self.Connector)
-          
+
     @property
     def prenote(self):
         """ Text that comes before the citation """
@@ -299,7 +299,7 @@ class NatBibCite(Base.cite):
             out.extend(a['text'])
             return out
         return ''
-        
+
     @property
     def separator(self):
         """ Separator for multiple items """
@@ -314,7 +314,7 @@ class NatBibCite(Base.cite):
         """ Determine if author should be a full name or shortened """
         if full or self.attributes.get('*modifier*'):
             return 'fullauthor'
-        doc = self.ownerDocument        
+        doc = self.ownerDocument
         # longnamesfirst means that only the first reference
         # gets the full length name, the rest use short names.
         cited = doc.userdata.getPath('bibliography/cited', [])
@@ -325,10 +325,10 @@ class NatBibCite(Base.cite):
         if full:
             return 'fullauthor'
         return 'author'
-        
+
     def isNumeric(self):
         return bibpunct.punctuation['style'] in ['n','s']
-        
+
     def isSuperScript(self):
         return bibpunct.punctuation['style'] == 's'
 
@@ -353,8 +353,8 @@ class NatBibCite(Base.cite):
             return item
         node = textnodes.pop(0)
         node.parentNode.replaceChild(node.cloneNode(True).capitalize() ,node)
-        return item        
-            
+        return item
+
 # class citep(NatBibCite):
 
 #     def numcitation(self):
@@ -394,7 +394,7 @@ class NatBibCite(Base.cite):
 #                 if duplicateyears == 0:
 #                     # Make a reference that points to the same item as
 #                     # the first citation in this set.  This will make
-#                     # hyperlinked output prettier since the 'a' will 
+#                     # hyperlinked output prettier since the 'a' will
 #                     # be linked to the same place as the reference that
 #                     # we just put out.
 #                     res.append('')
@@ -517,7 +517,7 @@ class citetfull(citet):
 
     def citation(self):
         """ Jones, Baker, and Williams (1990) """
-        return citet.citation(self, full=True)        
+        return citet.citation(self, full=True)
 
 class Citet(citet):
 
@@ -550,7 +550,7 @@ class citep(NatBibCite):
                     author = self.selectAuthorField(item.attributes['key'], full=full)
                     if i == 0 and capitalize:
                         res.extend(self.capitalize(item.bibcite.attributes[author]))
-                    else:            
+                    else:
                         res.extend(item.bibcite.attributes[author])
                     res.append(self.separator+' ')
             res.append(self.citeValue(item, text=text))
@@ -674,11 +674,11 @@ class citealtfull(citealt):
     def citation(self):
         """ Jones, Baker, and Williams 1990 """
         return citealt.citation(self, full=True)
-    
+
 class Citealt(citealt):
 
     def citation(self):
-        return citealt.citation(self, capitalize=True)   
+        return citealt.citation(self, capitalize=True)
 
 class citealp(NatBibCite):
 
@@ -708,7 +708,7 @@ class citealp(NatBibCite):
                 elif i == 0 and capitalize:
                     res.extend(self.capitalize(item.bibcite.attributes[author]))
                 else:
-                    res.extend(item.bibcite.attributes[author])              
+                    res.extend(item.bibcite.attributes[author])
                 res.append(self.separator+' ')
             res.append(self.citeValue(item))
             if i < (len(self.bibitems)-1):
@@ -749,7 +749,7 @@ class Citealp(citealp):
 
     def citation(self):
         return citealp.citation(self, capitalize=True)
-        
+
 class citeauthor(NatBibCite):
 
     def citation(self, full=False, capitalize=False):
@@ -783,10 +783,10 @@ class citefullauthor(citeauthor):
         return citeauthor.citation(self, full=True)
 
 class Citeauthor(citeauthor):
-    
+
     def citation(self):
         return citeauthor.citation(self, capitalize=True)
-        
+
 class citeyear(NatBibCite):
 
     def citation(self):
@@ -834,7 +834,7 @@ class citeyearpar(NatBibCite):
                 res.append(self.postnote)
         res.append(bibpunct.punctuation['close'])
         return res
-    
+
 class citetext(Base.Command):
     args = 'self'
     def digest(self, tokens):

--- a/src/plasTeX/Renderers/PageTemplate/__init__.py
+++ b/src/plasTeX/Renderers/PageTemplate/__init__.py
@@ -30,8 +30,10 @@ from plasTeX.Logging import getLogger
 log = getLogger(__name__)
 logger = log
 
-from six.moves import configparser as ConfigParser
+from six.moves import configparser
 from six import text_type
+
+ConfigParser = configparser.SafeConfigParser if sys.version_info[0] < 3 else configparser.ConfigParser
 
 # Support for Python string templates
 def stringtemplate(s, encoding='utf8',filename=None):
@@ -98,10 +100,12 @@ def copytree(src, dest, symlink=None):
                 os.makedirs(destpath)
                 try:
                     shutil.copymode(srcpath, destpath)
-                except: pass
+                except:
+                    pass
                 try:
                     shutil.copystat(srcpath, destpath)
-                except: pass
+                except:
+                    pass
         for f in files:
             if f.startswith('.'):
                 continue
@@ -154,7 +158,7 @@ class PageTemplate(BaseRenderer):
         node -- the Text node to process
 
         """
-        if not(getattr(node, 'isMarkup', None)):
+        if not getattr(node, 'isMarkup', None):
             node = node.replace('&', '&amp;')
             node = node.replace('<', '&lt;')
             node = node.replace('>', '&gt;')
@@ -216,7 +220,7 @@ class PageTemplate(BaseRenderer):
                     shutil.copy(item, os.path.join(dest,item))
 
         def _get_base_theme( theme_dir ):
-            p = ConfigParser.SafeConfigParser()
+            p = ConfigParser()
             p.read( os.path.join( theme_dir, 'theme_conf.ini' ) )
             for conf in (p,document.config):
                 if conf.has_option( 'general', 'theme-base' ):

--- a/src/plasTeX/TeX.py
+++ b/src/plasTeX/TeX.py
@@ -77,6 +77,7 @@ class TeX(object):
         self.ownerDocument = ownerDocument
 
         # Input source stack
+        # (Tokenizer, iter(Tokenizer))
         self.inputs = []
 
         # Auxiliary files loaded
@@ -164,7 +165,13 @@ class TeX(object):
 
         """
         if self.inputs:
-            self.inputs.pop()
+            old_input = self.inputs.pop()
+            try:
+                close = old_input[0].close
+            except AttributeError:
+                pass
+            else:
+                close()
         if self.inputs:
             self.currentInput = self.inputs[-1]
 
@@ -306,9 +313,8 @@ class TeX(object):
         createElement = self.ownerDocument.createElement
         ELEMENT_NODE = Macro.ELEMENT_NODE
 
-        while True:
+        for token in itertokens:
             # Get the next token
-            token = next(itertokens)
 
             # Token is null, ignore it
             if token is None:

--- a/src/plasTeX/Tokenizer.py
+++ b/src/plasTeX/Tokenizer.py
@@ -271,6 +271,13 @@ class Tokenizer(object):
         self.tell = source.tell
         self.lineNumber = 1
 
+        try:
+            # Let us be closable if the source is.
+            # We tend to do `Tokenizer(open(filename))` a lot
+            self.close = source.close
+        except AttributeError:
+            pass
+
 # There seems to be a problem with readline in Python 2.4 !!!
     def readline(self):
         read = self.read
@@ -419,7 +426,12 @@ class Tokenizer(object):
                 yield buffer.pop(0)
 
             # Get the next character
-            token = next(charIter)
+            try:
+                token = next(charIter)
+            except StopIteration:
+                # Don't let StopIteration bubble up, that's
+                # deprecated on Python 3 and produces warnings
+                return
 
             if token.nodeType == ELEMENT_NODE:
                 raise ValueError('Expanded tokens should never make it here')

--- a/src/plasTeX/__init__.py
+++ b/src/plasTeX/__init__.py
@@ -946,11 +946,16 @@ class UnrecognizedMacro(Macro):
     def __eq__(self, other):
         if not hasattr(other, 'nodeName'):
             return True
-        if other.nodeName in ['undefined','@undefined']:
+        if other.nodeName in ('undefined', '@undefined'):
             return True
         if isinstance(other, UnrecognizedMacro):
             return True
         return super(UnrecognizedMacro, self).__eq__(other)
+
+    # In Python 3, you must override __hash__ at the same level you
+    # override __eq__, even if you want to inherit.
+    def __hash__(self):
+        return super(UnrecognizedMacro, self).__hash__()
 
 class NewIf(Macro):
     """ Base class for all generated \\newifs """

--- a/src/plasTeX/__init__.py
+++ b/src/plasTeX/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import absolute_import, division, unicode_literals
+from __future__ import absolute_import, division, unicode_literals, print_function
 
 __version__ = '9.3'
 

--- a/src/plasTeX/tests/test_ArgumentParsing.py
+++ b/src/plasTeX/tests/test_ArgumentParsing.py
@@ -214,12 +214,12 @@ class ArgumentParsing(TestCase):
         assert arg == dimen(0), arg
 
         # Coerced dimen
-        s.input('{\mycount}')
+        s.input(r'{\mycount}')
         arg = s.readArgument(type='dimen')
         assert arg == dimen(120), arg
 
         # Coerced glue
-        s.input('{\myglue}')
+        s.input(r'{\myglue}')
         arg = s.readArgument(type='dimen')
         assert arg == dimen(10), arg
 
@@ -245,12 +245,12 @@ class ArgumentParsing(TestCase):
         assert arg == dimen('100pt'), arg
 
         # Set by other dimen
-        s.input('\mydimen')
+        s.input(r'\mydimen')
         arg = s.readArgument(type='Dimen')
         assert arg == dimen('12sp'), arg
 
         # Multiply by other dimen
-        s.input('3\mydimen')
+        s.input(r'3\mydimen')
         arg = s.readArgument(type='Dimen')
         assert arg == dimen('36sp'), arg
 
@@ -311,12 +311,12 @@ class ArgumentParsing(TestCase):
         assert arg == count(0), arg
 
         # Coerced dimen
-        s.input('{\mydimen}')
+        s.input(r'{\mydimen}')
         arg = s.readArgument(type='number')
         assert arg == count(12), arg
 
         # Coerced glue
-        s.input('{\myglue}')
+        s.input(r'{\myglue}')
         arg = s.readArgument(type='number')
         assert arg == count(10), arg
 
@@ -378,12 +378,12 @@ class ArgumentParsing(TestCase):
         assert arg == count('100'), arg
 
         # Set by other dimen
-        s.input('\mycount')
+        s.input(r'\mycount')
         arg = s.readArgument(type='Number')
         assert arg == count('120'), arg
 
         # Multiply by other dimen
-        s.input('3\mycount')
+        s.input(r'3\mycount')
         arg = s.readArgument(type='Number')
         assert arg == count('360'), arg
 
@@ -401,7 +401,7 @@ class ArgumentParsing(TestCase):
                     \newskip\myglue\myglue=10sp plus1pt minus2pt''')
         s.parse()
 
-        s.input('{1, \mycount, 3}')
+        s.input(r'{1, \mycount, 3}')
         arg = s.readArgument(type='list', subtype='int')
         assert arg == [1, 120, 3], arg
 
@@ -412,7 +412,7 @@ class ArgumentParsing(TestCase):
                     \newskip\myglue\myglue=10sp plus1pt minus2pt''')
         s.parse()
 
-        s.input('{one=1, two={\mycount} , three={3}}')
+        s.input(r'{one=1, two={\mycount} , three={3}}')
         arg = s.readArgument(type='dict', expanded=True)
         keys = list(arg.keys())
         keys.sort()

--- a/src/plasTeX/tests/test_CategoriesAndChars.py
+++ b/src/plasTeX/tests/test_CategoriesAndChars.py
@@ -19,7 +19,7 @@ class CategoryCodes(TestCase):
                 self.ownerDocument.context.catcode('$',11)
                 return Macro.parse(self, tex)
         s = TeX()
-        s.input('\code{this # is $ some & nasty _ text}&_2')
+        s.input(r'\code{this # is $ some & nasty _ text}&_2')
         s.ownerDocument.context['code'] = code
         tokens = [x for x in s]
 
@@ -33,7 +33,7 @@ class CategoryCodes(TestCase):
         tok = type(tokens[-3])
         cs = type(s.ownerDocument.createElement('active::&'))
         assert tok is cs, '"%s" != "%s"' % (tok, cs)
-    
+
 #       tok = type(tokens[-2])
 #       cs = type(s.ownerDocument.createElement('active::_'))
 #       assert tok is cs, '"%s" != "%s"' % (tok, cs)
@@ -42,7 +42,7 @@ class CategoryCodes(TestCase):
         class code(Macro):
             args = 'self'
         s = TeX()
-        s.input("{\catcode`\#=11\catcode`\$=11\catcode`\&=11\catcode`\_=11{this # is $ some & nasty _ text}}&_2")
+        s.input(r"{\catcode`\#=11\catcode`\$=11\catcode`\&=11\catcode`\_=11{this # is $ some & nasty _ text}}&_2")
         s.ownerDocument.context['code'] = code
         tokens = [x for x in s]
 
@@ -52,7 +52,7 @@ class CategoryCodes(TestCase):
         tok = type(tokens[-3])
         tab = type(s.ownerDocument.createElement('active::&'))
         assert tok is tab, '"%s" != "%s"' % (tok, tab)
-    
+
 #       tok = type(tokens[-1])
 #       tab = type(s.ownerDocument.createElement('active::_'))
 #       assert tok is tab, '"%s" != "%s"' % (tok, tab)
@@ -60,4 +60,3 @@ class CategoryCodes(TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/src/plasTeX/tests/test_Tokenizer.py
+++ b/src/plasTeX/tests/test_Tokenizer.py
@@ -2,46 +2,56 @@
 
 import unittest
 from unittest import TestCase
-from plasTeX import Macro
-from plasTeX.TeX import *
-from plasTeX.Tokenizer import *
 
-class Tokenizing(TestCase):
+from plasTeX.TeX import TeX
+from plasTeX.Tokenizer import BeginGroup
+from plasTeX.Tokenizer import EscapeSequence
+from plasTeX.Tokenizer import Other
+from plasTeX.Tokenizer import Space
+from plasTeX.Tokenizer import Letter
+from plasTeX.Tokenizer import EndGroup
+from plasTeX.Tokenizer import MathShift
+from plasTeX.Tokenizer import Alignment
+from plasTeX.Tokenizer import Parameter
+from plasTeX.Tokenizer import Superscript
+from plasTeX.Tokenizer import Subscript
+
+class TestTokenizing(TestCase):
 
     def testTokens(self):
-        tokens = [x for x in TeX().input('{\hskip 36 pt}').itertokens()]
-        expected = [BeginGroup('{'), 
-                    EscapeSequence('hskip'), 
+        tokens = [x for x in TeX().input(r'{\hskip 36 pt}').itertokens()]
+        expected = [BeginGroup('{'),
+                    EscapeSequence('hskip'),
                     Other('3'),
                     Other('6'),
                     Space(' '),
-                    Letter('p'), 
-                    Letter('t'), 
+                    Letter('p'),
+                    Letter('t'),
                     EndGroup('}')]
-        assert tokens == expected, '%s != %s' % (tokens, expected)
+        self.assertEqual(tokens, expected)
 
     def testComment(self):
         tokens = [x for x in TeX().input('line % comment').itertokens()]
-        expected = [Letter('l'), 
-                    Letter('i'), 
-                    Letter('n'), 
-                    Letter('e'), 
+        expected = [Letter('l'),
+                    Letter('i'),
+                    Letter('n'),
+                    Letter('e'),
                     Space(' ')]
-        assert tokens == expected, '%s != %s' % (tokens, expected)
+        self.assertEqual(tokens, expected)
 
     def testSymbols(self):
         tokens = [x for x in TeX().input('\\ { } $ & # ^ _ ~ %').itertokens()]
         expected = [EscapeSequence(' '),
-                    BeginGroup('{'), Space(' '), 
-                    EndGroup('}'), Space(' '), 
-                    MathShift('$'), Space(' '), 
-                    Alignment('&'), Space(' '), 
-                    Parameter('#'), Space(' '), 
-                    Superscript('^'), Space(' '), 
-                    Subscript('_'), Space(' '), 
+                    BeginGroup('{'), Space(' '),
+                    EndGroup('}'), Space(' '),
+                    MathShift('$'), Space(' '),
+                    Alignment('&'), Space(' '),
+                    Parameter('#'), Space(' '),
+                    Superscript('^'), Space(' '),
+                    Subscript('_'), Space(' '),
                     EscapeSequence('active::~'), Space(' ')]
-        assert tokens == expected, '%s != %s' % (tokens, expected)
-        
+        self.assertEqual(tokens, expected)
+
         tokens = [x for x in TeX().input(r'\\ \{ \} \$ \& \# \^ \_ \~ \%').itertokens()]
         expected = [EscapeSequence('\\'), Space(' '),
                     EscapeSequence('{'), Space(' '),
@@ -53,60 +63,61 @@ class Tokenizing(TestCase):
                     EscapeSequence('_'), Space(' '),
                     EscapeSequence('~'), Space(' '),
                     EscapeSequence('%')]
-        assert tokens == expected, '%s != %s' % (tokens, expected)
+        self.assertEqual(tokens, expected)
 
     def testDoubleSuper(self):
         tokens = [x for x in TeX().input('^^I ^^A ^^@ ^^M').itertokens()]
         expected = [Other('\x01'), Space(' ')]
-        assert tokens == expected, '%s != %s' % (tokens, expected)
+        self.assertEqual(tokens, expected)
 
     def testParagraph(self):
         tokens = [x for x in TeX().input('1\n   2\n   \n   3\n').itertokens()]
-        expected = [Other('1'), Space(' '), 
-                    Other('2'), Space(' '), 
-                    EscapeSequence('par'), 
+        expected = [Other('1'), Space(' '),
+                    Other('2'), Space(' '),
+                    EscapeSequence('par'),
                     Other('3'), Space(' ')]
-        assert tokens == expected, '%s != %s' % (tokens, expected)
-         
+        self.assertEqual(tokens, expected)
+
     def testExercises(self):
         """ Exercises in the TeX book """
         # 8.4
         tokens = [x for x in TeX().input(r' $x^2$~  \TeX  ^^C').itertokens()]
-        expected = [MathShift('$'), 
-                    Letter('x'), 
-                    Superscript('^'), 
-                    Other('2'), 
-                    MathShift('$'), 
-                    EscapeSequence('active::~'), 
-                    Space(' '), 
-                    EscapeSequence('TeX'), 
+        expected = [MathShift('$'),
+                    Letter('x'),
+                    Superscript('^'),
+                    Other('2'),
+                    MathShift('$'),
+                    EscapeSequence('active::~'),
+                    Space(' '),
+                    EscapeSequence('TeX'),
                     Other('\x03')]
-        assert tokens == expected, '%s != %s' % (tokens, expected)
-        
+        self.assertEqual(tokens, expected)
+
         # 8.5
         tokens = [x for x in TeX().input('Hi!\n\n\n').itertokens()]
-        expected = [Letter('H'), 
-                    Letter('i'), 
-                    Other('!'), 
-                    Space(' '), 
+        expected = [Letter('H'),
+                    Letter('i'),
+                    Other('!'),
+                    Space(' '),
                     EscapeSequence('par')]
-        assert tokens == expected, '%s != %s' % (tokens, expected)
+        self.assertEqual(tokens, expected)
 
         # 8.6
         tokens = [x for x in TeX().input(r'^^B^^BM^^A^^B^^C^^M^^@\M ').itertokens()]
-        expected = [Other('\x02'), 
-                    Other('\x02'), 
-                    Letter('M'), 
-                    Other('\x01'), 
-                    Other('\x02'), 
-                    Other('\x03'), 
-                    Space(' '), 
+        expected = [Other('\x02'),
+                    Other('\x02'),
+                    Letter('M'),
+                    Other('\x01'),
+                    Other('\x02'),
+                    Other('\x03'),
+                    Space(' '),
                     EscapeSequence('M')]
-        assert tokens == expected, '%s != %s' % (tokens, expected)
+        self.assertEqual(tokens, expected)
 
     def testParameters(self):
         tokens = [x for x in TeX().input(r'\def\foo#1[#2]{hi}').itertokens()]
+        # XXX: Bad test
+        self.assertTrue(tokens)
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,11 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = pypy, py27, py34, py35, pypy3
+envlist = pypy, py27, py34, py35, py36, pypy3
 
 [testenv]
 deps =
-     zope.testrunner
-     pyhamcrest
-     beautifulsoup4
+     .[test]
 # The CHAMELEON_CACHE makes a HUGE difference for PyPy.
 # Without it, PyPy 5.3 has a 3-5 MINUTE runtime; with it,
 # it's 30 seconds or less.


### PR DESCRIPTION
The first commit fixes the direct cause, a TypeError. This exposed the root cause, the fact that standard packages weren't getting loaded due to a change. This is fixed in the second commit.

The second commit also fixes most or all warnings issued during testing, especially timely closing of files. The output was too cluttered otherwise.